### PR TITLE
Add New Game Command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ pyproject.toml
 Pipfile
 Pipfile.lock
 data_transfer.py
+.vscode/

--- a/README.md
+++ b/README.md
@@ -24,7 +24,11 @@ A trivia game bot for your Twitch chat. To get started, visit [TwiviaBot's chann
 - Points are tracked separately in different Twitch channels.
 
 ### %leaderboard - Displays the top 5 users with the most points in the current channel.
-- Points are tracked separeately in different Twitch channels, so leaderboards will also be independent. 
+- Points are tracked separeately in different Twitch channels, so leaderboards will also be independent.
+
+### %newgame - Starts a new game in the current channel.
+- Only the **channel owner** or a **moderator** of the channel may start a new game.
+- Points are reset to 0 for all users in current channel only.
 
 ### %skip - Skips the current trivia game question.
 - Only the **channel owner** or a **moderator** of the channel may skip a question.


### PR DESCRIPTION
Feature:
- Adds a command to start a new game in the channel.

RBAC:
 - command can only be used by users with mod role or superuser 'itssport'

Functionality:
 - skips current question if one is active
 - messages the channel leaderboard
 - resets all user scores to 0
 - messages the channel signifying a new game

Usage:
```%newgame```

Example:
<img width="268" alt="Screenshot 2024-04-22 at 12 52 45 PM" src="https://github.com/gabrielsissom/TwiviaBot/assets/78822234/58297718-67c5-4681-a9ff-8e50e269d757">

Documentation:
 - added docs to the README

Other considerations:
 - %newgame command could be added as an optional argument to the existing %leaderboard command

Other changes:
- Modifies leaderboard command to ignore users with score of 0.


