### PR TITLE
Add Game Pause/Resume Command

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ A trivia game bot for your Twitch chat. To get started, visit [TwiviaBot's chann
 - Only the **channel owner** may start a new game.
 - Points are reset to 0 for all users in current channel only.
 
+### %game <pause|resume> - Pauses the game in the current channel.
+- Only the **channel owner** may pause and resume a game.
+- Points are maintained but no new questions can be started while game is paused.
+
 ### %skip - Skips the current trivia game question.
 - Only the **channel owner** or a **moderator** of the channel may skip a question.
 - Does **not** reset the cooldown set for the channel. 


### PR DESCRIPTION
Feature:
- Adds a command to pause/resume game in the channel.

RBAC:
- command can only be used by users with channel owner role or superuser 'itssport'

Functionality:
- pause
  - skips current question if one is active
  - blocks new trivia questions from starting
- resume
  - allows new trivia question to be started again

Database:
- add is_paused column to channels table

Other changes:
 - newgame command now resumes the game

Usage:
```
%game pause
%game resume
```

Example:
<img width="326" alt="Screenshot 2024-04-23 at 7 58 30 PM" src="https://github.com/gabrielsissom/TwiviaBot/assets/78822234/a212ce96-83aa-46c4-a6b0-b39d40e6cc24">

Documentation:
 - add command docs to README

Other considerations:
 - could use `%pausegame` and `%resumegame` commands instead
 - could use a channel status enum instead of is_paused boolean